### PR TITLE
Improve question generation hook and fix fill-in-the-blank

### DIFF
--- a/this-or-that/src/app/games/colors/page.tsx
+++ b/this-or-that/src/app/games/colors/page.tsx
@@ -1,26 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import GameBoard from "@/components/GameBoard";
-import { GameQuestion, generateColorQuestions } from "@/utils/gameUtils";
-import { GameSettings, getSettings } from "@/utils/settingsUtils";
+import { generateColorQuestions } from "@/utils/gameUtils";
+import { useGame } from "@/hooks/useGame";
 import { colorStyles, colorCardStyles } from "./styles";
 
 export default function ColorsGame() {
-  const [questions, setQuestions] = useState<GameQuestion[]>([]);
-  const [settings, setSettings] = useState<GameSettings>(getSettings("colors"));
-  
-  useEffect(() => {
-    // Generate questions when component mounts or settings change
-    setQuestions(generateColorQuestions(
-      settings.questionCount,
-      settings.optionsCount
-    ));
-  }, [settings]);
-  
-  const handleSettingsChange = (newSettings: GameSettings) => {
-    setSettings(newSettings);
-  };
+  const { questions, handleSettingsChange } = useGame("colors", (settings) =>
+    generateColorQuestions(settings.questionCount, settings.optionsCount)
+  );
   
   return (
     <GameBoard 

--- a/this-or-that/src/app/games/fill-in-the-blank/page.tsx
+++ b/this-or-that/src/app/games/fill-in-the-blank/page.tsx
@@ -1,26 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import GameBoard from "@/components/GameBoard";
-import { GameQuestion, generateFillInTheBlankQuestions } from "@/utils/gameUtils";
-import { GameSettings, getSettings } from "@/utils/settingsUtils";
+import { generateFillInTheBlankQuestions } from "@/utils/gameUtils";
+import { useGame } from "@/hooks/useGame";
 import { fillInTheBlankCardStyles } from "./styles";
 
 export default function FillInTheBlankGame() {
-  const [questions, setQuestions] = useState<GameQuestion[]>([]);
-  const [settings, setSettings] = useState<GameSettings>(getSettings("fill-in-the-blank"));
-  
-  useEffect(() => {
-    // Generate questions when component mounts or settings change
-    setQuestions(generateFillInTheBlankQuestions(
-      settings.questionCount,
-      settings.optionsCount
-    ));
-  }, [settings]);
-  
-  const handleSettingsChange = (newSettings: GameSettings) => {
-    setSettings(newSettings);
-  };
+  const { questions, handleSettingsChange } = useGame(
+    "fill-in-the-blank",
+    (settings) =>
+      generateFillInTheBlankQuestions(settings.questionCount, settings.optionsCount)
+  );
   
   return (
     <GameBoard 

--- a/this-or-that/src/app/games/letters/page.tsx
+++ b/this-or-that/src/app/games/letters/page.tsx
@@ -1,25 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import GameBoard from "@/components/GameBoard";
-import { GameQuestion, generateLetterQuestions } from "@/utils/gameUtils";
-import { GameSettings, getSettings } from "@/utils/settingsUtils";
+import { generateLetterQuestions } from "@/utils/gameUtils";
+import { useGame } from "@/hooks/useGame";
 
 export default function LettersGame() {
-  const [questions, setQuestions] = useState<GameQuestion[]>([]);
-  const [settings, setSettings] = useState<GameSettings>(getSettings("letters"));
-  
-  useEffect(() => {
-    // Generate questions when component mounts or settings change
-    setQuestions(generateLetterQuestions(
-      settings.questionCount,
-      settings.optionsCount
-    ));
-  }, [settings]);
-  
-  const handleSettingsChange = (newSettings: GameSettings) => {
-    setSettings(newSettings);
-  };
+  const { questions, handleSettingsChange } = useGame("letters", (settings) =>
+    generateLetterQuestions(settings.questionCount, settings.optionsCount)
+  );
   
   return (
     <GameBoard 

--- a/this-or-that/src/app/games/math/page.tsx
+++ b/this-or-that/src/app/games/math/page.tsx
@@ -1,26 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import GameBoard from "@/components/GameBoard";
-import { GameQuestion, generateMathQuestions } from "@/utils/gameUtils";
-import { GameSettings, getSettings } from "@/utils/settingsUtils";
+import { generateMathQuestions } from "@/utils/gameUtils";
+import { useGame } from "@/hooks/useGame";
 import { mathCardStyles } from "./styles";
 
 export default function MathGame() {
-  const [questions, setQuestions] = useState<GameQuestion[]>([]);
-  const [settings, setSettings] = useState<GameSettings>(getSettings("math"));
-  
-  useEffect(() => {
-    // Generate questions when component mounts or settings change
-    setQuestions(generateMathQuestions(
-      settings.questionCount,
-      settings.optionsCount
-    ));
-  }, [settings]);
-  
-  const handleSettingsChange = (newSettings: GameSettings) => {
-    setSettings(newSettings);
-  };
+  const { questions, handleSettingsChange } = useGame("math", (settings) =>
+    generateMathQuestions(settings.questionCount, settings.optionsCount)
+  );
   
   return (
     <GameBoard 

--- a/this-or-that/src/app/games/numbers/page.tsx
+++ b/this-or-that/src/app/games/numbers/page.tsx
@@ -1,27 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import GameBoard from "@/components/GameBoard";
-import { GameQuestion, generateNumberQuestions } from "@/utils/gameUtils";
-import { GameSettings, getSettings } from "@/utils/settingsUtils";
+import { generateNumberQuestions } from "@/utils/gameUtils";
+import { useGame } from "@/hooks/useGame";
 
 export default function NumbersGame() {
-  const [questions, setQuestions] = useState<GameQuestion[]>([]);
-  const [settings, setSettings] = useState<GameSettings>(getSettings("numbers"));
-  
-  useEffect(() => {
-    // Generate questions when component mounts or settings change
-    setQuestions(generateNumberQuestions(
-      settings.questionCount, 
-      settings.numberRange.min, 
+  const { questions, handleSettingsChange } = useGame("numbers", (settings) =>
+    generateNumberQuestions(
+      settings.questionCount,
+      settings.numberRange.min,
       settings.numberRange.max,
       settings.optionsCount
-    ));
-  }, [settings]);
-  
-  const handleSettingsChange = (newSettings: GameSettings) => {
-    setSettings(newSettings);
-  };
+    )
+  );
   
   return (
     <GameBoard 

--- a/this-or-that/src/app/games/patterns/page.tsx
+++ b/this-or-that/src/app/games/patterns/page.tsx
@@ -1,25 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import GameBoard from "@/components/GameBoard";
-import { GameQuestion, generatePatternQuestions } from "@/utils/gameUtils";
-import { GameSettings, getSettings } from "@/utils/settingsUtils";
+import { generatePatternQuestions } from "@/utils/gameUtils";
+import { useGame } from "@/hooks/useGame";
 
 export default function PatternsGame() {
-  const [questions, setQuestions] = useState<GameQuestion[]>([]);
-  const [settings, setSettings] = useState<GameSettings>(getSettings("patterns"));
-  
-  useEffect(() => {
-    // Generate questions when component mounts or settings change
-    setQuestions(generatePatternQuestions(
-      settings.questionCount,
-      settings.optionsCount
-    ));
-  }, [settings]);
-  
-  const handleSettingsChange = (newSettings: GameSettings) => {
-    setSettings(newSettings);
-  };
+  const { questions, handleSettingsChange } = useGame("patterns", (settings) =>
+    generatePatternQuestions(settings.questionCount, settings.optionsCount)
+  );
   
   return (
     <GameBoard 

--- a/this-or-that/src/app/games/shapes/page.tsx
+++ b/this-or-that/src/app/games/shapes/page.tsx
@@ -1,26 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import GameBoard from "@/components/GameBoard";
-import { GameQuestion, generateShapeQuestions } from "@/utils/gameUtils";
-import { GameSettings, getSettings } from "@/utils/settingsUtils";
+import { generateShapeQuestions } from "@/utils/gameUtils";
+import { useGame } from "@/hooks/useGame";
 import { shapeStyles, shapeCardStyles } from "./styles";
 
 export default function ShapesGame() {
-  const [questions, setQuestions] = useState<GameQuestion[]>([]);
-  const [settings, setSettings] = useState<GameSettings>(getSettings("shapes"));
-  
-  useEffect(() => {
-    // Generate questions when component mounts or settings change
-    setQuestions(generateShapeQuestions(
-      settings.questionCount,
-      settings.optionsCount
-    ));
-  }, [settings]);
-  
-  const handleSettingsChange = (newSettings: GameSettings) => {
-    setSettings(newSettings);
-  };
+  const { questions, handleSettingsChange } = useGame("shapes", (settings) =>
+    generateShapeQuestions(settings.questionCount, settings.optionsCount)
+  );
   
   return (
     <GameBoard 

--- a/this-or-that/src/hooks/useGame.ts
+++ b/this-or-that/src/hooks/useGame.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from "react";
+import { GameType, GameQuestion } from "@/utils/gameUtils";
+import { GameSettings, getSettings } from "@/utils/settingsUtils";
+
+export type QuestionGenerator = (settings: GameSettings) => GameQuestion[];
+
+/**
+ * Shared hook to generate questions and handle settings for different games.
+ * Provides a consistent state management pattern across game pages.
+ */
+export function useGame(gameType: GameType, generate: QuestionGenerator) {
+  const [questions, setQuestions] = useState<GameQuestion[]>([]);
+  const [settings, setSettings] = useState<GameSettings>(getSettings(gameType));
+
+  useEffect(() => {
+    setQuestions(generate(settings));
+  }, [settings, generate]);
+
+  const handleSettingsChange = (newSettings: GameSettings) => {
+    setSettings(newSettings);
+  };
+
+  return {
+    questions,
+    settings,
+    handleSettingsChange,
+  };
+}

--- a/this-or-that/src/utils/gameUtils.ts
+++ b/this-or-that/src/utils/gameUtils.ts
@@ -461,10 +461,12 @@ export function generateFillInTheBlankQuestions(count: number = 5, optionsCount:
   // Select random words from the list
   const selectedWords = [...fillInTheBlankWords]
     .sort(() => 0.5 - Math.random())
-    .slice(0, count);
+    .slice(0, count)
+    .map(word => ({ ...word }));
   
-  for (const word of selectedWords) {
-    const correctLetter = word.word[word.missingIndex];
+  for (const baseWord of selectedWords) {
+    let word = { ...baseWord };
+    let correctLetter = word.word[word.missingIndex];
     let attempts = 0;
     const maxAttempts = 100; // Prevent infinite loop
     
@@ -472,10 +474,10 @@ export function generateFillInTheBlankQuestions(count: number = 5, optionsCount:
     while (usedLetters.has(correctLetter) && attempts < maxAttempts) {
       // Try to find a different word with a unique missing letter
       const newWord = fillInTheBlankWords[Math.floor(Math.random() * fillInTheBlankWords.length)];
-      if (!usedLetters.has(newWord.word[newWord.missingIndex])) {
-        word.word = newWord.word;
-        word.missingIndex = newWord.missingIndex;
-        word.emoji = newWord.emoji;
+      const newLetter = newWord.word[newWord.missingIndex];
+      if (!usedLetters.has(newLetter)) {
+        word = { ...newWord };
+        correctLetter = newLetter;
         break;
       }
       attempts++;


### PR DESCRIPTION
## Summary
- add new `useGame` hook for consistent question/state management
- refactor individual game pages to use the new hook
- fix mutation bug in `generateFillInTheBlankQuestions`

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430c8bba0083228ff833c67fc9d054