### PR TITLE
Add GitHub Pages deployment for Next.js project

### DIFF
--- a/.github/workflows/nextjs-gh-pages.yml
+++ b/.github/workflows/nextjs-gh-pages.yml
@@ -1,0 +1,46 @@
+name: Deploy Next.js site to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "gh-pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: this-or-that
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: this-or-that/package-lock.json
+      - run: npm ci
+      - name: Build project
+        run: npm run build
+        env:
+          BASE_PATH: /${{ github.event.repository.name }}
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./this-or-that/out
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/this-or-that/next.config.ts
+++ b/this-or-that/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
+// Determine base path when running on GitHub Actions. This allows the app to be
+// served from a subfolder (the repository name) when deployed to GitHub Pages.
+const repoName = process.env.GITHUB_REPOSITORY?.split("/")[1];
+const basePath = process.env.BASE_PATH || (process.env.GITHUB_ACTIONS ? `/${repoName}` : "");
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "export",
+  trailingSlash: true,
+  basePath,
+  assetPrefix: basePath ? `${basePath}/` : undefined,
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure `next.config.ts` to export static site with dynamic base path
- add GitHub Actions workflow to build and deploy to GitHub Pages

## Testing
- `npm ci` *(fails: 5 high severity vulnerabilities)*
- `npm run build` *(fails to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68434309cb048322837834010b0516a7